### PR TITLE
Use logger instead of console logs

### DIFF
--- a/services/journeyService.ts
+++ b/services/journeyService.ts
@@ -16,6 +16,7 @@ import {
 // Import des sources de données existantes
 import { journeys as staticJourneys, Journey } from '@/utils/journeyData';
 import * as markdownParser from '@/utils/markdownParser';
+import logger from '@/utils/logger';
 
 /**
  * Détermine si nous sommes côté client ou serveur
@@ -119,7 +120,7 @@ export async function getAllJourneys(): Promise<JourneyContent[]> {
       return markdownJourneys;
     }
   } catch (error) {
-    console.warn('Error retrieving markdown journeys:', error);
+    logger.warn('Error retrieving markdown journeys:', error);
   }
   
   // Fallback sur les données statiques
@@ -139,7 +140,7 @@ export async function getAllJourneys(): Promise<JourneyContent[]> {
 export async function getJourneysByPersona(persona: PersonaType): Promise<JourneyContent[]> {
   // Vérifier si persona est undefined ou null pour éviter l'erreur toLowerCase()
   if (persona === undefined || persona === null) {
-    console.warn('getJourneysByPersona a été appelé avec une persona undefined ou null');
+    logger.warn('getJourneysByPersona a été appelé avec une persona undefined ou null');
     return [];
   }
   
@@ -208,17 +209,17 @@ const homePageJourneys = homePageJourneysRaw.map(journey => {
 
 export async function getJourneyBySlug(slug: string): Promise<JourneyContent | null> {
   if (!slug) {
-    console.error('getJourneyBySlug appelé avec un slug vide ou null');
+    logger.error('getJourneyBySlug appelé avec un slug vide ou null');
     return null;
   }
 
   const normalizedSlug = slug.toLowerCase().trim();
-  console.log(`Recherche du parcours avec le slug: ${normalizedSlug}`);
+  logger.log(`Recherche du parcours avec le slug: ${normalizedSlug}`);
   
   // Réimporter les données directement depuis le fichier source pour éviter les problèmes de cache
   // et s'assurer que nous avons les données les plus à jour
   const { journeys: latestJourneysRaw } = await import('@/data/journeys');
-  console.log('Données de parcours disponibles (réimportées):', latestJourneysRaw.map(j => j.metadata.slug));
+  logger.log('Données de parcours disponibles (réimportées):', latestJourneysRaw.map(j => j.metadata.slug));
   
   // Adapter les données réimportées pour qu'elles soient compatibles avec le type JourneyContent de @/types
   const latestJourneys = latestJourneysRaw.map(journey => {
@@ -261,19 +262,19 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
   // Essayer d'abord de trouver le parcours dans les données réimportées
   const latestJourney = latestJourneys.find(journey => journey.metadata.slug === normalizedSlug);
   if (latestJourney) {
-    console.log(`Parcours trouvé dans les données réimportées: ${latestJourney.metadata.title}`);
+    logger.log(`Parcours trouvé dans les données réimportées: ${latestJourney.metadata.title}`);
     return latestJourney;
   }
   
   // Essayer ensuite dans les données de la page d'accueil
   const homePageJourney = homePageJourneys.find(journey => journey.metadata.slug === normalizedSlug);
   if (homePageJourney) {
-    console.log(`Parcours trouvé dans les données de la page d'accueil: ${homePageJourney.metadata.title}`);
+    logger.log(`Parcours trouvé dans les données de la page d'accueil: ${homePageJourney.metadata.title}`);
     return homePageJourney;
   }
   
-  console.log(`Parcours non trouvé dans les données pour le slug: ${normalizedSlug}`);
-  console.log('Recherche dans les données statiques...');
+  logger.log(`Parcours non trouvé dans les données pour le slug: ${normalizedSlug}`);
+  logger.log('Recherche dans les données statiques...');
   
   // Côté client, utilise les données statiques
   if (isClient) {
@@ -310,7 +311,7 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
         const persona = titleMapping[matchingTitle];
         journey = allJourneys.find(j => j.metadata.profileType.toLowerCase() === persona.toLowerCase());
         if (journey) {
-          console.log(`Parcours trouvé par correspondance de titre: ${matchingTitle}`);
+          logger.log(`Parcours trouvé par correspondance de titre: ${matchingTitle}`);
         }
       }
     }
@@ -327,14 +328,14 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
         const persona = slugMapping[normalizedSlug];
         journey = allJourneys.find(j => j.metadata.profileType.toLowerCase() === persona.toLowerCase());
         if (journey) {
-          console.log(`Parcours trouvé par mapping de slug: ${normalizedSlug} -> ${persona}`);
+          logger.log(`Parcours trouvé par mapping de slug: ${normalizedSlug} -> ${persona}`);
         }
       }
     }
     
     // Si toujours aucun résultat, prendre le premier parcours comme fallback
     if (!journey && allJourneys.length > 0) {
-      console.warn(`Aucun parcours trouvé pour le slug ${normalizedSlug}, utilisation du premier parcours disponible comme fallback`);
+      logger.warn(`Aucun parcours trouvé pour le slug ${normalizedSlug}, utilisation du premier parcours disponible comme fallback`);
       journey = allJourneys[0];
     }
     
@@ -349,7 +350,7 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
       return markdownJourney;
     }
   } catch (error) {
-    console.warn(`Erreur lors de la récupération du journey ${normalizedSlug} depuis markdown:`, error);
+    logger.warn(`Erreur lors de la récupération du journey ${normalizedSlug} depuis markdown:`, error);
   }
   
   // Fallback sur les données statiques avec la même logique que côté client
@@ -404,7 +405,7 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
   
   // Si toujours aucun résultat, prendre le premier parcours comme fallback
   if (!journey && allJourneys.length > 0) {
-    console.warn(`Aucun parcours trouvé pour le slug ${normalizedSlug}, utilisation du premier parcours disponible comme fallback`);
+    logger.warn(`Aucun parcours trouvé pour le slug ${normalizedSlug}, utilisation du premier parcours disponible comme fallback`);
     journey = allJourneys[0];
   }
   

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,24 @@
+const isProd = process.env.NODE_ENV === 'production';
+
+export const logger = {
+  log: (...args: unknown[]): void => {
+    if (!isProd) {
+      // eslint-disable-next-line no-console
+      console.log(...args);
+    }
+  },
+  warn: (...args: unknown[]): void => {
+    if (!isProd) {
+      // eslint-disable-next-line no-console
+      console.warn(...args);
+    }
+  },
+  error: (...args: unknown[]): void => {
+    if (!isProd) {
+      // eslint-disable-next-line no-console
+      console.error(...args);
+    }
+  },
+};
+
+export default logger;

--- a/utils/markdownParser.ts
+++ b/utils/markdownParser.ts
@@ -1,4 +1,5 @@
 import matter from 'gray-matter';
+import logger from '@/utils/logger';
 
 // These imports will only be used server-side
 let fs: any;
@@ -30,8 +31,8 @@ export async function parseJourneyMarkdown(filePath: string): Promise<JourneyCon
 
   // Extract phases from frontmatter if available
   const frontmatterPhases = data.phases || [];
-  console.log('Frontmatter data:', data);
-  console.log('Frontmatter phases:', frontmatterPhases);
+  logger.log('Frontmatter data:', data);
+  logger.log('Frontmatter phases:', frontmatterPhases);
 
   // Extract title, subtitle, and tagline from the markdown
   const titleMatch = content.match(/## (.*?)\n/);
@@ -205,7 +206,7 @@ export function getJourneyFiles(): string[] {
 
   // Check if directory exists
   if (!fs.existsSync(journeyDir)) {
-    console.warn(`Journey directory not found at ${journeyDir}. Using fallback path.`);
+    logger.warn(`Journey directory not found at ${journeyDir}. Using fallback path.`);
     // Use absolute path as fallback
     const fallbackDir =
       '/home/alaeddine/Documents/Moneyfactory/pages_web_parcours/mfai-user-journeys/journeys';
@@ -215,7 +216,7 @@ export function getJourneyFiles(): string[] {
         .filter((file: string) => file.startsWith('From_') && file.endsWith('.md'));
       return fileNames.map((fileName: string) => path.join(fallbackDir, fileName));
     } else {
-      console.error('Fallback journey directory not found either!');
+      logger.error('Fallback journey directory not found either!');
       return [];
     }
   }
@@ -260,22 +261,22 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
   // Normalize the slug for comparison (replace underscores with hyphens)
   const normalizedSlug = slug.toLowerCase().replace(/_/g, '-');
 
-  console.log(`Looking for journey with slug: ${normalizedSlug}`);
+  logger.log(`Looking for journey with slug: ${normalizedSlug}`);
 
   // Get all journeys and find the one with the matching slug
   const journeys = await getAllJourneys();
 
   // Log all available journeys and their slugs for debugging
-  console.log('Available journeys:');
+  logger.log('Available journeys:');
   journeys.forEach(journey => {
-    console.log(`- Title: ${journey.metadata.title}, Slug: ${journey.metadata.slug}`);
+    logger.log(`- Title: ${journey.metadata.title}, Slug: ${journey.metadata.slug}`);
   });
 
   // Find the matching journey with exact match first, then partial match
   const exactMatch = journeys.find(journey => journey.metadata.slug === normalizedSlug);
 
   if (exactMatch) {
-    console.log(`Found exact match for slug: ${normalizedSlug}`);
+    logger.log(`Found exact match for slug: ${normalizedSlug}`);
     return exactMatch;
   }
 
@@ -285,10 +286,10 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
   );
 
   if (partialMatch) {
-    console.log(`Found partial match for slug: ${normalizedSlug} -> ${partialMatch.metadata.slug}`);
+    logger.log(`Found partial match for slug: ${normalizedSlug} -> ${partialMatch.metadata.slug}`);
     return partialMatch;
   }
 
-  console.log(`No journey found for slug: ${normalizedSlug}`);
+  logger.log(`No journey found for slug: ${normalizedSlug}`);
   return null;
 }


### PR DESCRIPTION
## Summary
- create a simple logger that silences output in production
- replace various console.log/warn/error statements with logger

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test --silent` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b144524b48328a3daa820ec9fc6bb