### PR TITLE
Refactor to use shared toast hook

### DIFF
--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -3,14 +3,7 @@ import { ChevronDown, Wallet, Link, Coins, Ghost, CircleDollarSign } from 'lucid
 import { useState } from 'react';
 import { useStore } from '../utils/store';
 import { Button } from './ui/button';
-// Create a local toast hook since we don't have the actual hook
-const useToast = () => {
-  return {
-    toast: (message: string, type: 'success' | 'error' | 'warning' | 'info') => {
-      console.log(`Toast: ${message} (${type})`);
-    },
-  };
-};
+import { useToast } from './ui/use-toast';
 
 const walletOptions = [
   { id: 'metamask', name: 'MetaMask', icon: CircleDollarSign },

--- a/pages/journey/[slug].tsx
+++ b/pages/journey/[slug].tsx
@@ -46,19 +46,7 @@ import { Progress } from '../../components/ui/progress';
 import { useStore } from '../../utils/store';
 import { useKeyboardNavigation } from '../../hooks/useKeyboardNavigation';
 import usePhaseFeedback from '../../hooks/usePhaseFeedback';
-
-// Local implementation of useToast hook
-const useToast = () => {
-  return {
-    toast: (message: string | { description: string; title?: string; variant?: string }) => {
-      if (typeof message === 'string') {
-        console.log(`Toast: ${message}`);
-      } else {
-        console.log(`Toast: ${message.title || 'Notification'} - ${message.description}`);
-      }
-    }
-  };
-};
+import { useToast } from '../../components/ui/use-toast';
 
 // Data and utilities
 import { JourneyMetadata } from '../../types/journey';


### PR DESCRIPTION
## Summary
- use `useToast` hook from shared component
- clean up local hook implementations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b144060d083289f1cf2c44d4fb5c9