### PR TITLE
Add logger utility docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ mfai-user-journeys/
 └── data/
 ```
 
+## Logger Utility
+
+Le fichier `utils/logger.ts` fournit une petite API pour centraliser les appels
+`console.log`, `console.warn` et `console.error`. Les messages sont affichés
+uniquement lorsque `NODE_ENV` n'est pas défini à `production`, ce qui permet de
+garder la console propre en environnement de production.
+
+Utilisation :
+
+```ts
+import logger from './utils/logger';
+
+logger.log('Message informatif');
+logger.warn('Avertissement');
+logger.error('Erreur');
+```
+
+Les journaux sont automatiquement supprimés en production.
+
 ## Contribution
 
 Les contributions sont les bienvenues ! N'hésitez pas à ouvrir une issue ou à soumettre une pull request.

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,18 @@
+export const logger = {
+  log: (...args: unknown[]): void => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(...args);
+    }
+  },
+  warn: (...args: unknown[]): void => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(...args);
+    }
+  },
+  error: (...args: unknown[]): void => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(...args);
+    }
+  },
+};
+export default logger;


### PR DESCRIPTION
## Summary
- document logger util in README
- add a simple logger that suppresses logs in production

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1af988188328835723d5e84eca26