### PR TITLE
Refactor console statements to use logger

### DIFF
--- a/components/Journey/Phases/PhaseFeedback.tsx
+++ b/components/Journey/Phases/PhaseFeedback.tsx
@@ -2,6 +2,7 @@ import { FC, useState } from 'react';
 import { Button } from '../../ui/button';
 import { Textarea } from '../../ui/textarea';
 import { Star } from 'lucide-react';
+import logger from '@/utils/logger';
 
 export interface PhaseFeedbackData {
   phaseIndex: number;
@@ -47,7 +48,7 @@ const PhaseFeedback: FC<PhaseFeedbackProps> = ({
       setRating(0);
       setComment('');
     } catch (error) {
-      console.error('Error submitting feedback:', error);
+      logger.error('Error submitting feedback:', error);
     } finally {
       setIsSubmitting(false);
     }

--- a/components/Wallet/NFTGate.tsx
+++ b/components/Wallet/NFTGate.tsx
@@ -4,6 +4,7 @@ import { useStore } from '../../utils/store';
 // Les fonctions hasNFT et hasNFTPass sont commentées car nous avons désactivé la vérification NFT
 // import { hasNFT, hasNFTPass } from '../../utils/nftUtils';
 import WalletConnect from './WalletConnect';
+import logger from '@/utils/logger';
 
 /**
  * NFTGate Component
@@ -53,7 +54,7 @@ const NFTGate: FC<NFTGateProps> = ({ children, requiredNFT, requiredPass, fallba
 
         setHasAccess(access);
       } catch (error) {
-        console.error('Error checking NFT access:', error);
+        logger.error('Error checking NFT access:', error);
         setHasAccess(false);
       } finally {
         setChecking(false);

--- a/components/Wallet/WalletConnect.tsx
+++ b/components/Wallet/WalletConnect.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useStore } from '../../utils/store';
 import { getUserNFTs } from '../../utils/nftUtils';
+import logger from '@/utils/logger';
 
 /**
  * WalletConnect Component
@@ -35,7 +36,7 @@ const WalletConnect: FC<WalletConnectProps> = ({
           // Add each NFT to the store individually
           nfts.forEach(nft => addNFT(nft.name));
         } catch (error) {
-          console.error('Error fetching NFTs:', error);
+          logger.error('Error fetching NFTs:', error);
         }
       }
     };
@@ -57,7 +58,7 @@ const WalletConnect: FC<WalletConnectProps> = ({
         onConnect(mockAddress);
       }
     } catch (error) {
-      console.error('Error connecting wallet:', error);
+      logger.error('Error connecting wallet:', error);
     }
   };
 

--- a/hooks/useCurrentJourney.ts
+++ b/hooks/useCurrentJourney.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useStore } from '@/utils/store';
 import { getJourneysByPersona } from '@/services/journeyService';
 import { PersonaType, JourneyContent } from '@/types';
+import logger from '@/utils/logger';
 
 /**
  * Custom hook to get current journey data based on selected persona
@@ -27,7 +28,7 @@ export const useCurrentJourney = () => {
           setJourney(null);
         }
       } catch (error) {
-        console.error('Error retrieving journey:', error);
+        logger.error('Error retrieving journey:', error);
         setJourney(null);
       }
     };

--- a/hooks/usePhaseFeedback.ts
+++ b/hooks/usePhaseFeedback.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { PhaseFeedbackData } from '../components/Journey/Phases/PhaseFeedback';
+import logger from '@/utils/logger';
 
 /**
  * Hook to handle phase feedback storage in localStorage
@@ -15,7 +16,7 @@ export function usePhaseFeedback(journeySlug: string) {
         setFeedbackData(JSON.parse(storedFeedback));
       }
     } catch (error) {
-      console.error('Error loading feedback data:', error);
+      logger.error('Error loading feedback data:', error);
     }
   }, [journeySlug]);
 
@@ -30,11 +31,11 @@ export function usePhaseFeedback(journeySlug: string) {
       localStorage.setItem(`journey_feedback_${journeySlug}`, JSON.stringify(updatedFeedback));
 
       // Log for debugging (can be connected to analytics later)
-      console.log('Feedback saved:', feedback);
+      logger.log('Feedback saved:', feedback);
 
       return true;
     } catch (error) {
-      console.error('Error saving feedback:', error);
+      logger.error('Error saving feedback:', error);
       return false;
     }
   };

--- a/lib/journey.ts
+++ b/lib/journey.ts
@@ -1,4 +1,5 @@
 import type { JourneyData } from '@/types/journey';
+import logger from '@/utils/logger';
 
 export async function getJourneyData(slug: string): Promise<JourneyData> {
   try {
@@ -8,7 +9,7 @@ export async function getJourneyData(slug: string): Promise<JourneyData> {
     }
     return await response.json();
   } catch (error) {
-    console.error('Error fetching journey data:', error);
+    logger.error('Error fetching journey data:', error);
     throw error;
   }
 }

--- a/pages/journey/[slug].tsx
+++ b/pages/journey/[slug].tsx
@@ -15,6 +15,7 @@ import ProofSection from '../../components/Journey/Rewards/ProofSection';
 import JourneySidebar from '../../components/Journey/JourneySidebar';
 import VerticalTimeline from '../../components/Journey/Timeline/VerticalTimeline';
 import PhaseFeedback from '../../components/Journey/Phases/PhaseFeedback';
+import logger from '@/utils/logger';
 // Missing JourneyIntro component
 const JourneyIntro = ({ journey }: any) => (
   <div className="mb-8 bg-gradient-to-br from-gray-800/70 to-gray-900/70 backdrop-blur-md rounded-xl p-5 border border-gray-700/50 shadow-lg">
@@ -123,7 +124,7 @@ const JourneyDetailPage: FC<JourneyDetailPageProps> = ({ journey }) => {
   // Effect to monitor journey changes (for debugging in development only)
   useEffect(() => {
     if (process.env.NODE_ENV === 'development' && !journey?.phases?.length) {
-      console.log('Notice: Using default phases as journey phases are empty');
+      logger.log('Notice: Using default phases as journey phases are empty');
     }
   }, [journey]);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -157,12 +158,12 @@ const JourneyDetailPage: FC<JourneyDetailPageProps> = ({ journey }) => {
   }, [safePhaseIndex, currentPhaseIndex]);
   
   useEffect(() => {
-    console.log('useEffect: storedPhase changed', storedPhase, 'currentPhaseIndex:', currentPhaseIndex);
+    logger.log('useEffect: storedPhase changed', storedPhase, 'currentPhaseIndex:', currentPhaseIndex);
     if (storedPhase) {
       // Find the index corresponding to the stored phase
       const index = phases.findIndex(p => p.name === (storedPhase as any).name);
       if (index !== -1 && index !== currentPhaseIndex) {
-        console.log('Updating currentPhaseIndex to match storedPhase index:', index);
+        logger.log('Updating currentPhaseIndex to match storedPhase index:', index);
         setCurrentPhaseIndex(index);
         // Force re-render
         setForceUpdate(prev => prev + 1);
@@ -371,7 +372,7 @@ const JourneyDetailPage: FC<JourneyDetailPageProps> = ({ journey }) => {
   
   // Handle feedback submission
   const handleFeedbackSubmit = useCallback((data: PhaseFeedbackData) => {
-    console.log('Feedback submitted:', data);
+    logger.log('Feedback submitted:', data);
     toast(`Feedback sent: Thank you for your experience feedback!`);
     // Add XP for submitting feedback
     addXP(25);
@@ -654,8 +655,8 @@ const JourneyDetailPage: FC<JourneyDetailPageProps> = ({ journey }) => {
                   whyItMatters: journey.whyItMatters as string,
                   finalRole: journey.finalRole as string
                 } as any}
-                onOpenZynoModal={() => console.log('Open Zyno modal')}
-                onNotifyClick={() => console.log('Notification clicked')}
+                onOpenZynoModal={() => logger.log('Open Zyno modal')}
+                onNotifyClick={() => logger.log('Notification clicked')}
                 mfaiBalance={'0'}
               />
             </div>
@@ -675,7 +676,7 @@ const JourneyDetailPage: FC<JourneyDetailPageProps> = ({ journey }) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  console.log('Starting getStaticPaths');
+  logger.log('Starting getStaticPaths');
   
   // Simplified approach: hardcode all known slugs
   const hardcodedSlugs = [
@@ -687,7 +688,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
     params: { slug }
   }));
   
-  console.log('Generated paths:', paths);
+  logger.log('Generated paths:', paths);
 
   return {
     paths,
@@ -697,16 +698,16 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   try {
-    console.log('Starting getStaticProps for slug:', params?.slug);
+    logger.log('Starting getStaticProps for slug:', params?.slug);
     const slug = params?.slug as string;
     
     // Import both data sources directly
     const { journeys: staticJourneys } = await import('@/utils/journeyData');
     const { journeys: dataJourneys } = await import('@/data/journeys');
     
-    console.log('Searching for journey with slug:', slug);
-    console.log('Available journeys in staticJourneys:', staticJourneys.map((j: any) => j.persona || j.label?.toLowerCase().replace(/ /g, '-')));
-    console.log('Available journeys in dataJourneys:', dataJourneys.map((j: any) => j.metadata?.slug));
+    logger.log('Searching for journey with slug:', slug);
+    logger.log('Available journeys in staticJourneys:', staticJourneys.map((j: any) => j.persona || j.label?.toLowerCase().replace(/ /g, '-')));
+    logger.log('Available journeys in dataJourneys:', dataJourneys.map((j: any) => j.metadata?.slug));
     
     // First look in static journeys
     let journey: any = null;
@@ -718,7 +719,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     );
     
     if (staticJourney) {
-      console.log('Journey found in staticJourneys:', staticJourney.label);
+      logger.log('Journey found in staticJourneys:', staticJourney.label);
       // Convert the static journey to the expected format
       journey = {
         metadata: {
@@ -753,13 +754,13 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       // Search in dataJourneys
       const dataJourney = dataJourneys.find((j: any) => j.metadata?.slug === slug);
       if (dataJourney) {
-        console.log('Journey found in dataJourneys:', dataJourney.metadata.title);
+        logger.log('Journey found in dataJourneys:', dataJourney.metadata.title);
         journey = dataJourney;
       }
     }
     
     if (!journey) {
-      console.log('No journey found for slug:', slug);
+      logger.log('No journey found for slug:', slug);
       return {
         notFound: true
       };
@@ -822,7 +823,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       revalidate: 3600,
     };
   } catch (error) {
-    console.error("Error in getStaticProps:", error);
+    logger.error("Error in getStaticProps:", error);
     // Return minimal data to avoid rendering errors
     return { 
       props: { 

--- a/pages/journeys/index.tsx
+++ b/pages/journeys/index.tsx
@@ -8,6 +8,7 @@ import { JourneyContent } from '@/types';
 import { GetStaticProps } from 'next';
 import { getAllJourneys } from '@/services/journeyService';
 import { useJourneyStore } from '@/stores';
+import logger from '@/utils/logger';
 
 /**
  * Journeys Page - Entry point showing all available user journeys
@@ -216,7 +217,7 @@ const JourneysPage: FC<JourneysPageProps> = ({ journeyData }) => {
                   journey={journey}
                   onSelect={slug => {
                     // Handle journey selection
-                    console.log('Selected journey:', slug);
+                    logger.log('Selected journey:', slug);
                     // Redirect to the journey page
                     router.push(`/journey/${slug}`);
                   }}
@@ -245,7 +246,7 @@ export const getStaticProps: GetStaticProps = async () => {
     );
 
     if (validatedJourneyData.length === 0) {
-      console.warn('No valid journey data found');
+      logger.warn('No valid journey data found');
       return {
         props: {
           journeyData: [],
@@ -261,7 +262,7 @@ export const getStaticProps: GetStaticProps = async () => {
       revalidate: 60,
     };
   } catch (error) {
-    console.error('Error fetching journey data:', error);
+    logger.error('Error fetching journey data:', error);
     return {
       props: {
         journeyData: [],

--- a/pages/support.tsx
+++ b/pages/support.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import MainLayout from '@/components/Layout/MainLayout';
 import { MessageSquare, HelpCircle, FileText, Send, Mail, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import logger from '@/utils/logger';
 
 /**
  * Support Page
@@ -24,7 +25,7 @@ const SupportPage = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     // In a real app, this would send the form data to a backend
-    console.log('Form submitted:', formData);
+    logger.log('Form submitted:', formData);
     setFormSubmitted(true);
     // Reset form after submission
     setFormData({

--- a/scripts/watch-ts.js
+++ b/scripts/watch-ts.js
@@ -1,20 +1,21 @@
 const { watch } = require('fs');
 const { exec } = require('child_process');
 const path = require('path');
+const logger = require('../utils/logger').default;
 
 const tsConfigPath = path.join(__dirname, '..', 'tsconfig.json');
 
-console.log('🔍 Surveillance du serveur TypeScript démarrée...');
+logger.log('🔍 Surveillance du serveur TypeScript démarrée...');
 
 watch(tsConfigPath, eventType => {
   if (eventType === 'change') {
-    console.log('🔄 Redémarrage du serveur TypeScript...');
+    logger.log('🔄 Redémarrage du serveur TypeScript...');
     exec('npm run restart-ts', (error, stdout, stderr) => {
       if (error) {
-        console.error('❌ Erreur:', error);
+        logger.error('❌ Erreur:', error);
         return;
       }
-      console.log('✅ Serveur TypeScript redémarré avec succès');
+      logger.log('✅ Serveur TypeScript redémarré avec succès');
     });
   }
 });

--- a/services/journeyService.ts
+++ b/services/journeyService.ts
@@ -16,6 +16,7 @@ import {
 // Import des sources de données existantes
 import { journeys as staticJourneys, Journey } from '@/utils/journeyData';
 import * as markdownParser from '@/utils/markdownParser';
+import logger from '@/utils/logger';
 
 /**
  * Détermine si nous sommes côté client ou serveur
@@ -119,7 +120,7 @@ export async function getAllJourneys(): Promise<JourneyContent[]> {
       return markdownJourneys;
     }
   } catch (error) {
-    console.warn('Error retrieving markdown journeys:', error);
+    logger.warn('Error retrieving markdown journeys:', error);
   }
   
   // Fallback sur les données statiques
@@ -139,7 +140,7 @@ export async function getAllJourneys(): Promise<JourneyContent[]> {
 export async function getJourneysByPersona(persona: PersonaType): Promise<JourneyContent[]> {
   // Vérifier si persona est undefined ou null pour éviter l'erreur toLowerCase()
   if (persona === undefined || persona === null) {
-    console.warn('getJourneysByPersona a été appelé avec une persona undefined ou null');
+    logger.warn('getJourneysByPersona a été appelé avec une persona undefined ou null');
     return [];
   }
   
@@ -208,17 +209,17 @@ const homePageJourneys = homePageJourneysRaw.map(journey => {
 
 export async function getJourneyBySlug(slug: string): Promise<JourneyContent | null> {
   if (!slug) {
-    console.error('getJourneyBySlug appelé avec un slug vide ou null');
+    logger.error('getJourneyBySlug appelé avec un slug vide ou null');
     return null;
   }
 
   const normalizedSlug = slug.toLowerCase().trim();
-  console.log(`Recherche du parcours avec le slug: ${normalizedSlug}`);
+  logger.log(`Recherche du parcours avec le slug: ${normalizedSlug}`);
   
   // Réimporter les données directement depuis le fichier source pour éviter les problèmes de cache
   // et s'assurer que nous avons les données les plus à jour
   const { journeys: latestJourneysRaw } = await import('@/data/journeys');
-  console.log('Données de parcours disponibles (réimportées):', latestJourneysRaw.map(j => j.metadata.slug));
+  logger.log('Données de parcours disponibles (réimportées):', latestJourneysRaw.map(j => j.metadata.slug));
   
   // Adapter les données réimportées pour qu'elles soient compatibles avec le type JourneyContent de @/types
   const latestJourneys = latestJourneysRaw.map(journey => {
@@ -261,19 +262,19 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
   // Essayer d'abord de trouver le parcours dans les données réimportées
   const latestJourney = latestJourneys.find(journey => journey.metadata.slug === normalizedSlug);
   if (latestJourney) {
-    console.log(`Parcours trouvé dans les données réimportées: ${latestJourney.metadata.title}`);
+    logger.log(`Parcours trouvé dans les données réimportées: ${latestJourney.metadata.title}`);
     return latestJourney;
   }
   
   // Essayer ensuite dans les données de la page d'accueil
   const homePageJourney = homePageJourneys.find(journey => journey.metadata.slug === normalizedSlug);
   if (homePageJourney) {
-    console.log(`Parcours trouvé dans les données de la page d'accueil: ${homePageJourney.metadata.title}`);
+    logger.log(`Parcours trouvé dans les données de la page d'accueil: ${homePageJourney.metadata.title}`);
     return homePageJourney;
   }
   
-  console.log(`Parcours non trouvé dans les données pour le slug: ${normalizedSlug}`);
-  console.log('Recherche dans les données statiques...');
+  logger.log(`Parcours non trouvé dans les données pour le slug: ${normalizedSlug}`);
+  logger.log('Recherche dans les données statiques...');
   
   // Côté client, utilise les données statiques
   if (isClient) {
@@ -310,7 +311,7 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
         const persona = titleMapping[matchingTitle];
         journey = allJourneys.find(j => j.metadata.profileType.toLowerCase() === persona.toLowerCase());
         if (journey) {
-          console.log(`Parcours trouvé par correspondance de titre: ${matchingTitle}`);
+          logger.log(`Parcours trouvé par correspondance de titre: ${matchingTitle}`);
         }
       }
     }
@@ -327,14 +328,14 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
         const persona = slugMapping[normalizedSlug];
         journey = allJourneys.find(j => j.metadata.profileType.toLowerCase() === persona.toLowerCase());
         if (journey) {
-          console.log(`Parcours trouvé par mapping de slug: ${normalizedSlug} -> ${persona}`);
+          logger.log(`Parcours trouvé par mapping de slug: ${normalizedSlug} -> ${persona}`);
         }
       }
     }
     
     // Si toujours aucun résultat, prendre le premier parcours comme fallback
     if (!journey && allJourneys.length > 0) {
-      console.warn(`Aucun parcours trouvé pour le slug ${normalizedSlug}, utilisation du premier parcours disponible comme fallback`);
+      logger.warn(`Aucun parcours trouvé pour le slug ${normalizedSlug}, utilisation du premier parcours disponible comme fallback`);
       journey = allJourneys[0];
     }
     
@@ -349,7 +350,7 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
       return markdownJourney;
     }
   } catch (error) {
-    console.warn(`Erreur lors de la récupération du journey ${normalizedSlug} depuis markdown:`, error);
+    logger.warn(`Erreur lors de la récupération du journey ${normalizedSlug} depuis markdown:`, error);
   }
   
   // Fallback sur les données statiques avec la même logique que côté client
@@ -404,7 +405,7 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
   
   // Si toujours aucun résultat, prendre le premier parcours comme fallback
   if (!journey && allJourneys.length > 0) {
-    console.warn(`Aucun parcours trouvé pour le slug ${normalizedSlug}, utilisation du premier parcours disponible comme fallback`);
+    logger.warn(`Aucun parcours trouvé pour le slug ${normalizedSlug}, utilisation du premier parcours disponible comme fallback`);
     journey = allJourneys[0];
   }
   

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -3,6 +3,7 @@ import { useWallet as useSolanaWallet } from '@solana/wallet-adapter-react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import { useCallback, useEffect } from 'react';
 import { useStore } from '../../utils/store';
+import logger from '@/utils/logger';
 
 export const useWallet = () => {
   const { toast } = useToast();
@@ -18,7 +19,7 @@ export const useWallet = () => {
         description: 'Your wallet has been connected successfully.',
       });
     } catch (error) {
-      console.error('Error connecting wallet:', error);
+      logger.error('Error connecting wallet:', error);
       toast({
         title: 'Connection Error',
         description: 'Failed to connect wallet. Please try again.',
@@ -35,7 +36,7 @@ export const useWallet = () => {
         description: 'Your wallet has been disconnected successfully.',
       });
     } catch (error) {
-      console.error('Error disconnecting wallet:', error);
+      logger.error('Error disconnecting wallet:', error);
       toast({
         title: 'Disconnection Error',
         description: 'Failed to disconnect wallet. Please try again.',

--- a/stores/createTestStore.ts
+++ b/stores/createTestStore.ts
@@ -1,4 +1,5 @@
 import { createJourneyServiceMocks } from '@/tests/mocks/mockUtils';
+import logger from '@/utils/logger';
 
 /**
  * Création des mocks standardisés pour les services
@@ -41,7 +42,7 @@ export const createTestStore = () => {
         const journeys = await mockGetAllJourneys();
         set({ journeys, loading: false });
       } catch (error) {
-        console.error('Erreur lors du chargement des journeys:', error);
+        logger.error('Erreur lors du chargement des journeys:', error);
         set({ 
           error: error instanceof Error ? `Error fetching journeys: ${error.message}` : 'Erreur inconnue',
           loading: false 

--- a/stores/journeyStore.ts
+++ b/stores/journeyStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { JourneyContent, JourneyPhase, PersonaType } from '@/types';
 import { getAllJourneys, getJourneysByPersona, getJourneyBySlug, isPhaseUnlocked } from '@/services/journeyService';
+import logger from '@/utils/logger';
 
 /**
  * Interface for the journeys store
@@ -63,7 +64,7 @@ export const useJourneyStore = create<JourneyState>()(persist(
       
       set({ journeys, loading: false, error: null });
     } catch (error) {
-      console.error('Error loading journeys:', error);
+      logger.error('Error loading journeys:', error);
       
       // More descriptive and categorized error message
       let errorMessage = 'An error occurred while loading journeys.';
@@ -112,7 +113,7 @@ export const useJourneyStore = create<JourneyState>()(persist(
         set({ currentJourney: journeys[0] });
       }
     } catch (error) {
-      console.error(`Error loading journeys for ${persona}:`, error);
+      logger.error(`Error loading journeys for ${persona}:`, error);
       
       // More descriptive and categorized error message
       let errorMessage = `An error occurred while loading journeys for "${persona}".`;
@@ -159,7 +160,7 @@ export const useJourneyStore = create<JourneyState>()(persist(
         });
       }
     } catch (error) {
-      console.error(`Error loading journey ${slug}:`, error);
+      logger.error(`Error loading journey ${slug}:`, error);
       
       // More descriptive and categorized error message
       let errorMessage = `An error occurred while loading the journey "${slug}".`;

--- a/tests/mocks/mockUtils.ts
+++ b/tests/mocks/mockUtils.ts
@@ -6,6 +6,7 @@
  */
 
 import { getTestJourneys } from './journeyMocks';
+import logger from '@/utils/logger';
 
 /**
  * Crée un mock pour getAllJourneys
@@ -22,7 +23,7 @@ export const createMockGetJourneysByPersona = () => {
   return jest.fn().mockImplementation((persona: string | undefined | null) => {
     // Vérifier si persona est undefined ou null pour éviter l'erreur toLowerCase()
     if (persona === undefined || persona === null) {
-      console.warn('mockGetJourneysByPersona a été appelé avec une persona undefined ou null');
+      logger.warn('mockGetJourneysByPersona a été appelé avec une persona undefined ou null');
       return Promise.resolve([]);
     }
     

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,11 @@
+const logger = {
+  log: (...args: any[]) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(...args);
+    }
+  },
+  warn: (...args: any[]) => console.warn(...args),
+  error: (...args: any[]) => console.error(...args),
+};
+
+export default logger;

--- a/utils/markdownParser.ts
+++ b/utils/markdownParser.ts
@@ -12,6 +12,7 @@ if (typeof window === 'undefined') {
 
 // Import centralized types
 import { JourneyContent, JourneyMetadata, JourneyPhase, JourneyReward } from '@/types';
+import logger from '@/utils/logger';
 
 // Re-export types for backward compatibility
 export type { JourneyContent, JourneyMetadata, JourneyPhase, JourneyReward };
@@ -30,8 +31,8 @@ export async function parseJourneyMarkdown(filePath: string): Promise<JourneyCon
 
   // Extract phases from frontmatter if available
   const frontmatterPhases = data.phases || [];
-  console.log('Frontmatter data:', data);
-  console.log('Frontmatter phases:', frontmatterPhases);
+  logger.log('Frontmatter data:', data);
+  logger.log('Frontmatter phases:', frontmatterPhases);
 
   // Extract title, subtitle, and tagline from the markdown
   const titleMatch = content.match(/## (.*?)\n/);
@@ -207,7 +208,7 @@ export function getJourneyFiles(): string[] {
 
   // Check if directory exists
   if (!fs.existsSync(journeyDir)) {
-    console.error(`Journey directory not found at ${journeyDir}.`);
+    logger.error(`Journey directory not found at ${journeyDir}.`);
     return [];
   }
 
@@ -251,22 +252,22 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
   // Normalize the slug for comparison (replace underscores with hyphens)
   const normalizedSlug = slug.toLowerCase().replace(/_/g, '-');
 
-  console.log(`Looking for journey with slug: ${normalizedSlug}`);
+  logger.log(`Looking for journey with slug: ${normalizedSlug}`);
 
   // Get all journeys and find the one with the matching slug
   const journeys = await getAllJourneys();
 
   // Log all available journeys and their slugs for debugging
-  console.log('Available journeys:');
+  logger.log('Available journeys:');
   journeys.forEach(journey => {
-    console.log(`- Title: ${journey.metadata.title}, Slug: ${journey.metadata.slug}`);
+    logger.log(`- Title: ${journey.metadata.title}, Slug: ${journey.metadata.slug}`);
   });
 
   // Find the matching journey with exact match first, then partial match
   const exactMatch = journeys.find(journey => journey.metadata.slug === normalizedSlug);
 
   if (exactMatch) {
-    console.log(`Found exact match for slug: ${normalizedSlug}`);
+    logger.log(`Found exact match for slug: ${normalizedSlug}`);
     return exactMatch;
   }
 
@@ -276,10 +277,10 @@ export async function getJourneyBySlug(slug: string): Promise<JourneyContent | n
   );
 
   if (partialMatch) {
-    console.log(`Found partial match for slug: ${normalizedSlug} -> ${partialMatch.metadata.slug}`);
+    logger.log(`Found partial match for slug: ${normalizedSlug} -> ${partialMatch.metadata.slug}`);
     return partialMatch;
   }
 
-  console.log(`No journey found for slug: ${normalizedSlug}`);
+  logger.log(`No journey found for slug: ${normalizedSlug}`);
   return null;
 }

--- a/utils/nftUtils.ts
+++ b/utils/nftUtils.ts
@@ -6,6 +6,7 @@
  */
 
 import { useStore } from './store';
+import logger from '@/utils/logger';
 
 // Types
 export interface NFT {
@@ -34,7 +35,7 @@ export const getUserNFTs = async (
   // This is a mock implementation
   // In production, this would call Moralis, Thirdweb, or Metaplex APIs
 
-  console.log(`Fetching NFTs for ${address} on ${chain}`);
+  logger.log(`Fetching NFTs for ${address} on ${chain}`);
 
   // Mock data for development
   const mockNFTs: Record<string, NFT[]> = {
@@ -156,7 +157,7 @@ export const mintNFT = async (
   // Mock implementation
   // In production, this would call Thirdweb SDK, Metaplex, or a custom contract
 
-  console.log(`Minting NFT to ${address}`, metadata);
+  logger.log(`Minting NFT to ${address}`, metadata);
 
   // Simulate network delay
   await new Promise(resolve => setTimeout(resolve, 1500));

--- a/utils/unifiedJourneyData.ts
+++ b/utils/unifiedJourneyData.ts
@@ -5,6 +5,7 @@
 
 import { journeys as staticJourneys } from './journeyData';
 import { journeys as dataJourneys } from '../data/journeys';
+import logger from '@/utils/logger';
 
 // Type pour les parcours unifiés
 export interface UnifiedJourney {
@@ -75,4 +76,4 @@ export function getJourneyBySlug(slug: string): UnifiedJourney | undefined {
 export const availableSlugs = unifiedJourneys.map(journey => journey.slug);
 
 // Journeys pour débogage
-console.log('Slugs disponibles:', availableSlugs);
+logger.log('Slugs disponibles:', availableSlugs);


### PR DESCRIPTION
## Summary
- introduce simple logger wrapper
- replace direct `console` calls with `logger` in hooks, components, pages, services, and utilities
- require logger in Node scripts

## Testing
- `npm run lint` *(fails: Invalid ESLint options)*
- `npm test` *(fails: 6 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685b1af7737c83288749934ed46f1644